### PR TITLE
Try to perform login if Enter is pressed on the password input field

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -86,6 +86,11 @@ function Login(props) {
                 id="password"
                 autoComplete="current-password"
                 onChange={handleOnChangeInput}
+                onKeyDown={(event => {
+                  if (event.key === 'Enter') {
+                    handleLogin();
+                  }
+                })}
               />
             </Grid>
             <Grid item xs={12}>


### PR DESCRIPTION
Improve login UX on Desktop by triggering login when Enter is pressed in the password field.
Previously, one had to either click the login button or press Tab + Enter, which added unnecessary friction.